### PR TITLE
add link to rolod0x

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [De-mixing TornadoCash & RailGun](https://x.com/officer_cia/status/1742939031615221914)
 - [nansen.ai](https://nansen.ai)
 - [metasleuth.io](https://metasleuth.io)
+- [rolod0x.io](https://rolod0x.io/) - private open source address book, works on any site/chain
 - [explorer.swiss-knife.xyz](https://explorer.swiss-knife.xyz/)
 - [Explorers List](https://sovs.notion.site/Block-Explorers-8dcaed059c844e3b8f9b67b8eb90174a)
 - [explorer.0x.org](https://explorer.0x.org)


### PR DESCRIPTION
[rolod0x](https://rolod0x.io/) is a free / open source cross-browser extension providing a private onchain address book for any site and any chain.