### PR TITLE
feat: add XHuntr — X (Twitter) community sniper (social-layer monitoring tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Etherscan Transforms for Maltego](https://www.maltego.com/transform-hub/etherscan/)
 - [GraphSense Maltego Transform](https://github.com/INTERPOL-Innovation-Centre/GraphSense-Maltego-transform)
 - [cielo.finance](https://cielo.finance/)
+- [xhuntr.com](https://xhuntr.com) - X (Twitter) community sniper — real-time Telegram alerts when alpha hunters create/join X communities, post CAs before tweeting publicly, or multiple tracked accounts converge on the same community (social layer before on-chain)
 - [AI+Blockchain Tracking](https://twitter.com/betashop/status/1643529200375066626)
 - [List of Tools by Alchemy](https://www.alchemy.com/top/defi-tools)
 - [eigenphi.io/mev/eigentx](https://eigenphi.io/mev/eigentx)


### PR DESCRIPTION
Adds **XHuntr** to the Data-Analysis tools section, alongside `cielo.finance`.

**XHuntr** (https://xhuntr.com) is the only X community sniper for Solana — a Telegram bot that monitors X accounts and fires instant alerts when:

- A tracked account **creates or joins an X community** — before any public tweet
- A tracked account **posts a contract address inside an X community** — before the public call
- **2+ tracked accounts converge** on the same X community (coordinated movement signal)
- A tracked account **changes their pinned tweet** or renames a community they control

This is the **social layer** before on-chain activity — XHuntr fires 24-48 hours before wallet trackers like Cielo or Nansen see any transaction, because it catches the coordination that happens on X before traders move capital.

Useful for on-chain investigators who want to understand *why* wallets moved — the social coordination context that precedes the on-chain action.

Site: https://xhuntr.com | Telegram: https://t.me/XHuntrbot