### PR TITLE
Add rektradar.io to Data-Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [De-mixing TornadoCash & RailGun](https://x.com/officer_cia/status/1742939031615221914)
 - [nansen.ai](https://nansen.ai)
 - [onchainrisk.io](https://onchainrisk.io) - multi-chain wallet analysis, risk scoring, fund flow tracing
+- [rektradar.io](https://rektradar.io/) - Ethereum scam detector with mempool monitoring, deployer-graph clustering and factory-pattern detection. Surfaces 80+ on-chain flags per contract, groups related scams by common funder, free unlimited web checks.
 - [metasleuth.io](https://metasleuth.io)
 - [rolod0x.io](https://rolod0x.io/) - private open source address book, works on any site/chain
 - [explorer.swiss-knife.xyz](https://explorer.swiss-knife.xyz/)


### PR DESCRIPTION
Adds [rektradar.io](https://rektradar.io/) to the **Data-Analysis** section under `I - Tools List`.

RektRadar is an Ethereum scam-detection tool that fits naturally next to onchainrisk.io and 0xscope.com: it analyzes the deployer wallet's funding graph, clusters scam contracts by common funder, and surfaces 80+ on-chain flags per contract. Public dataset covers 78k+ tokens analyzed at deployment with ~36k classified as scams (risk score >= 70).

Free unlimited web checks, no signup. Source code is open (14 microservices: https://github.com/mik3fly-lab).