### PR TITLE
Add Xquik social intelligence tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@
 - [Valid.Network](https://valid.network/crypto-insights)
 - [Draw EVM contract byte code](https://github.com/DanielVF/evm-contract-draw)
 - [Twitter Social Graph](https://github.com/Nican/Furland)
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - X data API, MCP server, SDKs, and webhooks for public tweet search, account lookup, follower export, monitors, and media workflows that add off-chain social context to crypto investigations.
 - [chainbroker.io](https://chainbroker.io)
 - [cryptofees.info](https://cryptofees.info)
 - [stablecoins.wtf](https://stablecoins.wtf)


### PR DESCRIPTION
## Summary
- Add Xquik to the Data-Analysis tools list as an off-chain X data source for crypto investigations.
- Keep the entry focused on public tweet search, account lookup, follower export, monitors, media workflows, MCP, SDKs, and webhooks.

## Validation
- `git diff --check`
- Verified the Xquik repository link resolves.
- Checked README, all-state PRs, all-state issues, and discussions for existing Xquik entries.
- Reviewed the diff for private implementation details, secrets, badges, and unsupported claims.
