### PR TITLE
fix: honest network support for cryptoaml.ai (BTC, ETH, TRX only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 - [TRM Labs](https://www.trmlabs.com/products/forensics)
 - [scorechain.com](https://www.scorechain.com)
 - [CoinPath](https://bitquery.io/products/coinpath)
+- [cryptoaml.ai](https://cryptoaml.ai) - free AML checker for 30+ blockchains (BTC, ETH, USDT/TRC20, TRX, SOL, BNB) — OFAC sanctions, darknet exposure & risk score, no registration required
 - [Storyline](https://blog.chainalysis.com/reports/introducing-chainalysis-storyline)
 - [metadock](https://github.com/blocksecteam/metadock)
 - [SpyderLab AML](https://spyderlab.org)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@
 - [TRM Labs](https://www.trmlabs.com/products/forensics)
 - [scorechain.com](https://www.scorechain.com)
 - [CoinPath](https://bitquery.io/products/coinpath)
-- [cryptoaml.ai](https://cryptoaml.ai) - free AML checker for 30+ blockchains (BTC, ETH, USDT/TRC20, TRX, SOL, BNB) — OFAC sanctions, darknet exposure & risk score, no registration required
+- [cryptoaml.ai](https://cryptoaml.ai) - free AML checker for BTC, ETH & TRX/USDT-TRC20 — OFAC sanctions, darknet exposure & risk score, no registration required
 - [Storyline](https://blog.chainalysis.com/reports/introducing-chainalysis-storyline)
 - [metadock](https://github.com/blocksecteam/metadock)
 - [SpyderLab AML](https://spyderlab.org)


### PR DESCRIPTION
The previous submission (#33) listed "30+ blockchains" which is inaccurate — the tool currently supports 3 networks: BTC, ETH, and TRX/USDT-TRC20.

This PR corrects the description to be honest about actual support.

**Before:** `free AML checker for 30+ blockchains (BTC, ETH, USDT/TRC20, TRX, SOL, BNB)`
**After:** `free AML checker for BTC, ETH & TRX/USDT-TRC20`

SOL and BNB were listed but are not actually supported yet.