### PR TITLE
Add Deep Blue Alpha — Ethereum whale intelligence platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 - [De-mixing TornadoCash & RailGun](https://x.com/officer_cia/status/1742939031615221914)
 - [nansen.ai](https://nansen.ai)
+- [deepbluealpha.io](https://deepbluealpha.io) - Real-time Ethereum whale wallet tracker — monitors 10,000+ wallets block-by-block, net flow per token across 1H/24H/7D windows, free public API, no signup required
 - [onchainrisk.io](https://onchainrisk.io) - multi-chain wallet analysis, risk scoring, fund flow tracing
 - [rektradar.io](https://rektradar.io/) - Ethereum scam detector with mempool monitoring, deployer-graph clustering and factory-pattern detection. Surfaces 80+ on-chain flags per contract, groups related scams by common funder, free unlimited web checks.
 - [metasleuth.io](https://metasleuth.io)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 - [dappradar.com](https://dappradar.com)
 - [dextools.io](https://www.dextools.io/app/)
 - [uniwhales.io](https://uniwhales.io)
+- [deepbluealpha.io](https://deepbluealpha.io) — Real-time Ethereum whale intelligence. Tracks 23,000+ whale wallets with live feed, sentiment index, conviction scoring, and alerts.
 - [ensideas.com](https://ensideas.com)
 - [ens.vision](https://ens.vision)
 - [flipsidecrypto.xyz](https://sdk.flipsidecrypto.xyz/shroomdk)


### PR DESCRIPTION
Adds [Deep Blue Alpha](https://deepbluealpha.io) to the tools list.

**What it does:** Real-time Ethereum whale intelligence platform that tracks 23,000+ whale wallets block by block — live feed, sentiment index, conviction scoring, and alerts.

**Why it fits this list:** Complements existing entries like uniwhales.io, Nansen, and Arkham with a focus on whale wallet behavior analysis, net flow tracking, and multi-wallet convergence signals.

- Free tier available (no signup required for core features)
- 150+ published research articles on whale behavior
- Public API endpoints for whale sentiment data