### PR TITLE
Add PublicAML — free non-profit AML/KYT screening

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
 - [Storyline](https://blog.chainalysis.com/reports/introducing-chainalysis-storyline)
 - [metadock](https://github.com/blocksecteam/metadock)
 - [SpyderLab AML](https://spyderlab.org)
+- [PublicAML](https://publicaml.org) - free non-profit AML/KYT & sanctions screening for BTC/ETH/BNB/TRON, no API key
 
 **Specific:**
 


### PR DESCRIPTION
Adds PublicAML to the Clusterizers list. It's a non-profit crypto AML/KYT tool — wallet risk scoring, sanctions screening and scam/hack attribution — free with no account or API key, covering BTC/ETH/BNB Chain/TRON. Fills the "genuinely free" gap next to the enterprise vendors already listed.

- Site: https://publicaml.org
- Free API (no key): https://intelapi.publicaml.org/v1/enrich