### PR TITLE
Add Web3ID Intelligence API (x402 on-chain/market intelligence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 - [De-mixing TornadoCash & RailGun](https://x.com/officer_cia/status/1742939031615221914)
 - [nansen.ai](https://nansen.ai)
+- [web3id.xyz](https://web3id.xyz) - x402-native market & on-chain intelligence API (DeFi TVL, stablecoin monitoring, FX, wallet/IP tools). Pay per call in USDC on Base, no API key.
 - [onchainrisk.io](https://onchainrisk.io) - multi-chain wallet analysis, risk scoring, fund flow tracing
 - [rektradar.io](https://rektradar.io/) - Ethereum scam detector with mempool monitoring, deployer-graph clustering and factory-pattern detection. Surfaces 80+ on-chain flags per contract, groups related scams by common funder, free unlimited web checks.
 - [metasleuth.io](https://metasleuth.io)


### PR DESCRIPTION
Adds web3id.xyz to the Data-Analysis tools list — x402-native market & on-chain intelligence (DeFi TVL, stablecoin monitoring, FX, wallet/IP tools). Pay per call in USDC on Base, no API key.