### PR TITLE
Add telem.news incident feed to Hacks DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@
 - [web3rekt.com](https://www.web3rekt.com/)
 - [newsletter.blockthreat.io](https://newsletter.blockthreat.io/)
 - [rekt.news](https://rekt.news/)
+- [telem.news/security/incidents](https://telem.news/security/incidents)
 
 ## II - VR & 3D
 


### PR DESCRIPTION
Adding the Telem incident feed to the Hacks DBs section — a continuously updated record of DeFi exploits, hacks and rug pulls (date, protocol, and an original attributed brief per incident).

I run Telem. The feed is free — no login, no paywall. A security-only RSS feed exists at https://telem.news/rss/security.xml if useful.

Happy to adjust the entry format if you'd prefer it different.