### PR TITLE
Add Base Transaction Decoder (transaction decode + risk-check provenance, Base chain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@
 - [Yet another awesome list of doxxed EVM wallets](https://twitter.com/krinweb3/status/1631087086874001408)
 - [Eth Tx Decoder](https://antoncoding.github.io/eth-tx-decoder)
 - [Ethereum input data decoder](https://lab.miguelmota.com/ethereum-input-data-decoder)
+- [Base Transaction Decoder](https://0200project.com)
 - [Cancel Ethereum Transaction](https://github.com/mds1/Cancel-Ethereum-Transactions)
 - [bitaml.com](https://bitaml.com)
 - [btcrecover](https://github.com/gurnec/btcrecover)


### PR DESCRIPTION
Disclosure: this is my own tool, adding it per the README's open invitation.

**Base Transaction Decoder** - decodes a single Base-chain transaction hash into strict, deterministic JSON: asset movements by direction, counterparties, gas cost in USD, revert status, and action classification (swap / bridge / wrap / LP / lending). Every response includes a `checks` object stating which risk lookups actually ran and which were unavailable - explicit provenance rather than silent gaps, which matters for investigation work where "the check didn't run" and "the check found nothing" are different findings.

Scope honesty: Base mainnet only. 50 free calls per IP per 24h, then $0.02/call (x402) - so an investigator can verify a handful of transactions without an account, key, or wallet.

Placed next to the other transaction decoders. If paid tools or single-chain tools don't fit your criteria, close away - no hard feelings.
