### PR TITLE
Add aidecisions.ai/check (free multi-chain wallet screening) to Data-Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [De-mixing TornadoCash & RailGun](https://x.com/officer_cia/status/1742939031615221914)
 - [nansen.ai](https://nansen.ai)
 - [onchainrisk.io](https://onchainrisk.io) - multi-chain wallet analysis, risk scoring, fund flow tracing
+- [aidecisions.ai/check](https://aidecisions.ai/check) - free multi-chain wallet screening (Ethereum, Bitcoin, Tron, Base, Arbitrum, Gnosis): sanctions hit, mixer exposure, risk tier; no account, 5 checks/day; label tooling open source
 - [rektradar.io](https://rektradar.io/) - Ethereum scam detector with mempool monitoring, deployer-graph clustering and factory-pattern detection. Surfaces 80+ on-chain flags per contract, groups related scams by common funder, free unlimited web checks.
 - [metasleuth.io](https://metasleuth.io)
 - [rolod0x.io](https://rolod0x.io/) - private open source address book, works on any site/chain


### PR DESCRIPTION
Adds **aidecisions.ai/check** to Data-Analysis, next to onchainrisk.io.

Free, rate-limited wallet screening (5 checks/day, no account) across Ethereum, Bitcoin, Tron, Base, Arbitrum and Gnosis: sanctions hit, mixer exposure and a risk tier from the same live screening line the API serves. Labels come from primary public sources (OFAC SDN, court records, regulator registers); the label tooling is Apache-2.0 (github.com/ai-decisions/openlabels).

Disclosure: I am the founder of AI DECISIONS.